### PR TITLE
manage pending http request count in store

### DIFF
--- a/src/components/SplashScreen.vue
+++ b/src/components/SplashScreen.vue
@@ -36,7 +36,7 @@ export default {
       return this.$store.state.showSplash
     },
     loadingData () {
-      return this.$store.state.loadingData
+      return this.$store.getters.loadingData
     },
     tourIsActive () {
       return this.$store.tourIsActive

--- a/src/main.js
+++ b/src/main.js
@@ -19,8 +19,22 @@ Object.defineProperty(Vue.prototype, '$axios', { value: axios })
 Object.defineProperty(Vue.prototype, '$shepherd', { value: shepherd })
 Object.defineProperty(Vue.prototype, '$moment', { value: moment })
 
-// TODO: use this to show loading spinners while resources load.
-window.pendingRequests = 0
+// Wire in two listeners that will keep track of open
+// HTTP requests.
+Vue.prototype.$axios.interceptors.request.use(function (config) {
+  store.commit('incrementPendingHttpRequest')
+  return config
+}, function (error) {
+  return Promise.reject(error)
+})
+
+// Add a response interceptor
+Vue.prototype.$axios.interceptors.response.use(function (response) {
+  store.commit('decrementPendingHttpRequest')
+  return response
+}, function (error) {
+  return Promise.reject(error)
+})
 
 // Include styles for some libraries here.
 require('../node_modules/bootstrap-sass/assets/stylesheets/_bootstrap.scss')

--- a/src/store.js
+++ b/src/store.js
@@ -134,6 +134,12 @@ export default new Vuex.Store({
     },
     hideFireGraph (state) {
       state.fireGraphVisible = false
+    },
+    incrementPendingHttpRequest (state) {
+      state.pendingHttpRequests++
+    },
+    decrementPendingHttpRequest (state) {
+      state.pendingHttpRequests--
     }
   },
   // Some getters here are just used for watching global state changes.


### PR DESCRIPTION
 * When you go to to the Fire map, you should see the same blocking "Loading data please wait..." until the underlying data has been loaded.
 * pending HTTP request state is saved in the store.