### PR TITLE
destroy Fire plotly object & release window resize event

### DIFF
--- a/src/components/Maps/AK_Fires_Graph.vue
+++ b/src/components/Maps/AK_Fires_Graph.vue
@@ -88,9 +88,7 @@ export default {
   },
   mounted () {
     // Attach global listener
-    window.onresize = () => {
-      Plotly.Plots.resize(this.$refs.plotly)
-    }
+    window.addEventListener('resize', this.resizeGraph)
 
     var processGraphData = (data) => {
       let timeSeries = data
@@ -140,8 +138,15 @@ export default {
         graphLayout,
         graphOptions
       )
+      this.resizeGraph()
+    },
+    resizeGraph () {
       Plotly.Plots.resize(this.$refs.plotly)
     }
+  },
+  beforeDestroy () {
+    window.removeEventListener('resize', this.resizeGraph)
+    Plotly.Plots.purge(this.$refs.plotly)
   }
 }
 </script>


### PR DESCRIPTION
Previously, when you had navigated to the Fire map then gone to another map, the `window.resize` event wasn't cleared so there was a JS console error because the Plotly element wasn't present on the new map.  This fixes that error.  To test, go to the Fire map, look at the graph, then go back to the main screen, then go to the IAM map.  There should be no JS error.

There still may be some jank with the graph resizing properly (see #14).