### PR TITLE
ensure splash screen is displayed when switching maps

### DIFF
--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -56,6 +56,9 @@ export default {
     maps.right.map = this.$L.map('map-2', this.getBaseMapAndLayers())
     this.addLayers()
   },
+  destroyed () {
+    this.$store.commit('resetState')
+  },
   watch: {
     dualMaps () {
       this.$nextTick(function () {

--- a/src/store.js
+++ b/src/store.js
@@ -205,6 +205,18 @@ export default new Vuex.Store({
     },
     decrementPendingHttpRequest (state) {
       state.pendingHttpRequests--
+    },
+    // Reset the map to some defaults.
+    // Called when a map is destroyed, such as when
+    // user navigates between maps.
+    resetState (state) {
+      this.commit('disableSyncMaps')
+      this.commit('hideDualMaps')
+      this.commit('endTour')
+      this.commit('hideSidebar')
+
+      // Show splash screen by default!
+      this.commit('showSplash')
     }
   },
   getters: {


### PR DESCRIPTION
Previous behavior was that switching between maps (open a map, then click "About this site & other maps", then clicking another map) failed to show the Splash screen.  Added a cleanup hook to the `Map` component and the store.