### PR TITLE
Implement better way to handle custom map buttons in LayerMenu

### DIFF
--- a/src/components/LayerMenu.vue
+++ b/src/components/LayerMenu.vue
@@ -13,7 +13,7 @@
         About this map&hellip;
       </label>
 
-      <label id="showDualMaps" class="mobile-hidden btn btn-primary info" @click="toggleDualMaps()">
+      <label class="mobile-hidden btn btn-primary info" @click="toggleDualMaps()">
         <span v-show="!dualMaps">
           <span v-show="!dualMaps" class="glyphicon glyphicon-unchecked"></span>
           |
@@ -23,7 +23,7 @@
         Split / single map
       </label>
 
-      <label id="syncDualMaps" class="mobile-hidden btn btn-primary info" :class="{ 'btn-success': syncMaps }" v-show="dualMaps" @click="toggleSyncMaps()">
+      <label class="mobile-hidden btn btn-primary info" :class="{ 'btn-success': syncMaps }" v-show="dualMaps" @click="toggleSyncMaps()">
         <span class="glyphicon glyphicon-flash"></span>
         &nbsp;
         Synchronize maps
@@ -34,17 +34,16 @@
         &nbsp;
         Take a tour of this map&hellip;
       </label>
-        <!-- <a ng-show="map.distribution_url" id="downloadMap" class="mobile-hidden btn btn-primary info" :ng-href="map.distribution_url">
-        <span class="glyphicon glyphicon-download-alt"></span>
-        &nbsp;
-        Download data
-        </a> -->
 
-      <label class="mobile-hidden btn btn-primary" @click="showFireGraph()">
-        <span class="glyphicon glyphicon-signal"></span>
-        &nbsp;
-        Graph large fire seasons&hellip;
-      </label>
+      <layer-menu-button-item
+        v-for="(button, index) in buttons"
+        :key="index"
+        :glyphicon="button.glyphicon"
+        :classes="button.classes"
+        :callback="button.callback"
+        :text="button.text"
+      ></layer-menu-button-item>
+
     </div>
   </div>
 </div>
@@ -52,11 +51,14 @@
 
 <script>
 import LayerList from './LayerList'
+import LayerMenuButtonItem from './LayerMenuButtonItem'
+
 export default {
   name: 'LayerMenu',
-  props: ['map'],
+  props: ['map', 'buttons'],
   components: {
-    'layer-list': LayerList
+    'layer-list': LayerList,
+    'layer-menu-button-item': LayerMenuButtonItem
   },
   computed: {
     dualMaps () {
@@ -84,9 +86,6 @@ export default {
     },
     toggleSyncMaps () {
       this.$store.commit('toggleSyncMaps')
-    },
-    showFireGraph () {
-      this.$store.commit('showFireGraph')
     }
   }
 }
@@ -109,7 +108,7 @@ export default {
       width: 16em;
     }
 
-    #showDualMaps {
+    /deep/ .mobile-hidden {
       @media screen and (max-width: 768px) {
         display: none;
       }

--- a/src/components/LayerMenu.vue
+++ b/src/components/LayerMenu.vue
@@ -7,33 +7,35 @@
   <div v-show="layerMenuVisibility" class="menu-wrapper">
     <layer-list></layer-list>
     <div class="map-tools form-inline">
-      <label class="btn btn-primary info" @click="showSplash()">
-        <span class="glyphicon glyphicon-question-sign"></span>
-        &nbsp;
-        About this map&hellip;
-      </label>
 
-      <label class="mobile-hidden btn btn-primary info" @click="toggleDualMaps()">
-        <span v-show="!dualMaps">
-          <span v-show="!dualMaps" class="glyphicon glyphicon-unchecked"></span>
-          |
-        </span>
-        <span class="glyphicon glyphicon-unchecked"></span>
-        &nbsp;
-        Split / single map
-      </label>
+      <layer-menu-button-item
+        glyphicon="question-sign"
+        :callback="showSplash"
+        text="About this map"
+      ></layer-menu-button-item>
 
-      <label class="mobile-hidden btn btn-primary info" :class="{ 'btn-success': syncMaps }" v-show="dualMaps" @click="toggleSyncMaps()">
-        <span class="glyphicon glyphicon-flash"></span>
-        &nbsp;
-        Synchronize maps
-      </label>
+      <layer-menu-button-item
+        :class="{ 'btn-success': dualMaps }"
+        classes="mobile-hidden"
+        glyphicon="resize-horizontal"
+        :callback="toggleDualMaps"
+        text="Split / single map"
+      ></layer-menu-button-item>
 
-      <label class="mobile-hidden btn btn-primary" @click="startTour()">
-        <span class="glyphicon glyphicon-question-sign"></span>
-        &nbsp;
-        Take a tour of this map&hellip;
-      </label>
+      <layer-menu-button-item
+        :class="{ 'btn-success': syncMaps }"
+        v-show="dualMaps"
+        glyphicon="flash"
+        :callback="toggleSyncMaps"
+        text="Synchronize maps"
+      ></layer-menu-button-item>
+
+      <layer-menu-button-item
+        glyphicon="question-sign"
+        classes="mobile-hidden"
+        :callback="startTour"
+        text="Take a tour of this map"
+      ></layer-menu-button-item>
 
       <layer-menu-button-item
         v-for="(button, index) in buttons"

--- a/src/components/LayerMenuButtonItem.vue
+++ b/src/components/LayerMenuButtonItem.vue
@@ -1,0 +1,29 @@
+<template>
+<label :class="[classes, 'btn btn-primary']"
+  @click="callback">
+  <span :class="['glyphicon', 'glyphicon-' + glyphicon]"></span>
+  &nbsp;
+  {{ text }}
+</label>
+</template>
+
+<script>
+export default {
+  name: 'LayerMenuButtonItem',
+  props: [
+    'glyphicon',
+    'classes',
+    'callback',
+    'text'
+  ]
+}
+</script>
+
+<style type="sass" scoped>
+label {
+  display: block;
+  margin: 1ex 0;
+  text-align: left;
+  width: 16em;
+}
+</style>

--- a/src/components/Maps/AK_Fires.vue
+++ b/src/components/Maps/AK_Fires.vue
@@ -1,9 +1,8 @@
 <template>
 <div id="mv-ak-fires">
   <h1 class="map-title">{{ title }}</h1>
-  <layer-menu></layer-menu>
-  <splash-screen
-    :abstract="abstract"></splash-screen>
+  <layer-menu :buttons="buttons"></layer-menu>
+  <splash-screen :abstract="abstract"></splash-screen>
   <mv-map
     ref="map"
     :base-layer-options="baseLayerOptions"
@@ -88,6 +87,17 @@ export default {
     fireJson: {
       get () { return this.$localStorage.get('fireJson') },
       set (value) { this.$localStorage.set('fireJson', value) }
+    },
+    // Custom buttons for menu
+    buttons () {
+      return [
+        {
+          text: 'Graph large fire seasons',
+          glyphicon: 'signal',
+          classes: 'mobile-hidden',
+          callback: this.showFireGraph
+        }
+      ]
     },
     tour () {
       let tour
@@ -323,6 +333,9 @@ export default {
     this.fetchFireData()
   },
   methods: {
+    showFireGraph () {
+      this.$store.commit('showFireGraph')
+    },
     fetchFireData () {
       // Helper function to rebuild Leaflet objects
       // from either localStorage or HTTP request

--- a/src/components/Maps/IAM.vue
+++ b/src/components/Maps/IAM.vue
@@ -1,7 +1,9 @@
 <template>
 <div>
   <h1 class="map-title">{{ title }}</h1>
-  <layer-menu></layer-menu>
+  <layer-menu
+    :buttons="buttons"
+  ></layer-menu>
   <splash-screen
     :abstract="abstract"></splash-screen>
   <mv-map
@@ -41,6 +43,13 @@ export default {
         version: '1.3',
         continuousWorld: true // needed for non-3857 projs
       },
+      buttons: [
+        {
+          text: 'Dataset information',
+          glyphicon: 'new-window',
+          callback: this.openDatasetInformation
+        }
+      ],
       layers: [
         {
           'abstract': 'This layer shows cultural sites and buildings, as well as protected areas in the IAM area. Arctic Alaska has a long history of inhabitants, settlers, and traders since the earliest families crossed the Bering Land Bridge some 20,000 years ago. Cultural sites and structures are important artifacts. “Protected areas” are defined here as areas designated to preserve cultural and/or recreational features and activities.\n\n<a href="https://docs.google.com/document/u/1/d/1MayMZ6fIfz40tBLhftiisQVpHoGPJuFKxEtkMMcLi88/pub" target="_blank">More info and data access</a>',
@@ -137,6 +146,11 @@ export default {
           zIndex: 1000
         })
       )
+    }
+  },
+  methods: {
+    openDatasetInformation () {
+      window.open('https://docs.google.com/document/u/1/d/1MayMZ6fIfz40tBLhftiisQVpHoGPJuFKxEtkMMcLi88/pub')
     }
   }
 }


### PR DESCRIPTION
Previously, the "Show Fire Graph" button was put in the `LayerMenu` component, so it rendered on every map.  That's not right!

This PR fixes this by:
 * Create a new component, `LayerMenuButtonItem` (name ok?) to implement the buttons
 * Accept a new prop, `buttons`, from the parent component (which is one of the maps, like `AK_Fires.vue`) which is an array of button definitions.  If present, these are rendered.
 * Move custom button definition/code into the map that needs it, out of `LayerMenu`.  Both the Fire and IAM map have custom buttons.
 * Replace existing buttons to use new `LayerMenuButtonItem` components.

Caveats/notes:
 * This code no longer switches to show dual icons when Dual Maps is disabled vs. one icon when enabled.  I chose to do this because it simplifies the code (all buttons use same code) and it felt like an OK tradeoff.  I took another look at the glyph icons and picked one (horizontal-resize) that I felt _may_ capture the action's feeling, not real sure.