### PR TITLE
refactor fire map state out of global store object

### DIFF
--- a/src/components/Maps/AK_Fires.vue
+++ b/src/components/Maps/AK_Fires.vue
@@ -38,6 +38,22 @@ var secondFirePolygons
 var secondFireMarkers
 var secondFireLayerGroup
 
+// Define the store methods that will be used here
+const fireStore = { // eslint-disable-line no-unused-vars
+  state: {
+    // True if the fire graph is visible
+    fireGraphVisible: false
+  },
+  mutations: {
+    showFireGraph (state) {
+      state.fireGraphVisible = true
+    },
+    hideFireGraph (state) {
+      state.fireGraphVisible = false
+    }
+  }
+}
+
 export default {
   name: 'AK_Fires',
   extends: MapInstance,
@@ -299,6 +315,10 @@ export default {
     }
   },
   created () {
+    // Register this map's store with the global store
+    this.$store.registerModule('fire', fireStore)
+
+    // Set up icon markers
     let FireIcon = this.$L.Icon.extend({
       options: {
         iconUrl: '/static/active_fire.png',

--- a/src/components/Maps/AK_Fires.vue
+++ b/src/components/Maps/AK_Fires.vue
@@ -342,6 +342,10 @@ export default {
   mounted () {
     this.fetchFireData()
   },
+  beforeDestroy () {
+    // Remove the store module when the component is destroyed.
+    this.$store.unregisterModule('fire')
+  },
   methods: {
     fetchFireData () {
       // Helper function to rebuild Leaflet objects

--- a/src/components/Maps/AK_Fires_Graph.vue
+++ b/src/components/Maps/AK_Fires_Graph.vue
@@ -79,7 +79,7 @@ export default {
   name: 'AK_Fires_Graph',
   computed: {
     visible () {
-      return this.$store.state.fireGraphVisible
+      return this.$store.state.fire.fireGraphVisible
     },
     fireTimeSeries: {
       get () { return this.$localStorage.get('fireTimeSeries') },

--- a/src/store.js
+++ b/src/store.js
@@ -65,10 +65,7 @@ export default new Vuex.Store({
     syncMaps: false,
 
     // True if tour is active
-    tourIsActive: false,
-
-    // True if the fire graph is visible
-    fireGraphVisible: false
+    tourIsActive: false
   },
   mutations: {
     // This function is used to initialize the layers in the store.
@@ -193,12 +190,6 @@ export default new Vuex.Store({
     },
     disableSyncMaps (state) {
       state.syncMaps = false
-    },
-    showFireGraph (state) {
-      state.fireGraphVisible = true
-    },
-    hideFireGraph (state) {
-      state.fireGraphVisible = false
     },
     incrementPendingHttpRequest (state) {
       state.pendingHttpRequests++


### PR DESCRIPTION
This pull request refactors the state used by the Fire map out of the global store and into a dynamic module which is registered in the store.  There are no user-facing changes to behavior.

There will likely be a merge conflict or something needing resolution with pull request #21, because the code responsible for showing/hiding the fire chart is being moved around there.  Depending on the order these get merged, the correct code will need to be put into place to test this.