### PR TITLE
remove fire icon from scope of Vue component

### DIFF
--- a/src/components/Maps/AK_Fires.vue
+++ b/src/components/Maps/AK_Fires.vue
@@ -37,6 +37,8 @@ var fireLayerGroup
 var secondFirePolygons
 var secondFireMarkers
 var secondFireLayerGroup
+var activeFireIcon
+var inactiveFireIcon
 
 export default {
   name: 'AK_Fires',
@@ -292,10 +294,7 @@ export default {
           'name': 'fireareahistory',
           'title': 'Historical extent, 1940-2016'
         }
-      ],
-      // Will initialize these in the created() method
-      activeFireIcon: undefined,
-      inactiveFireIcon: undefined
+      ]
     }
   },
   created () {
@@ -310,8 +309,8 @@ export default {
       }
     })
 
-    this.activeFireIcon = new FireIcon()
-    this.inactiveFireIcon = new FireIcon({
+    activeFireIcon = new FireIcon()
+    inactiveFireIcon = new FireIcon({
       iconUrl: '/static/inactive_fire.png'
     })
 
@@ -385,7 +384,7 @@ export default {
           // Reverse order from what we need
           var coords = this.getCentroid2(polygonCoordinates)
           var icon = this.isFireActive(feature.properties)
-            ? this.activeFireIcon : this.inactiveFireIcon
+            ? activeFireIcon : inactiveFireIcon
 
           fireMarkers.push(
             this.$L.marker(new this.$L.latLng([coords[1], coords[0]]), {icon: icon}).bindPopup(this.getFireMarkerPopupContents(


### PR DESCRIPTION
Minor performance boost here (thought it would be more noticeable).  Was attempting to reduce the lag between activating/showing the Fire Layer and when it appears (less than a second but still laggy).  The only further performance improvement for the future I can think of would be to render and then adjust transparency/visibility instead of adding/removing the layer from the map, and that'd be a much different rewrite.