### PR TITLE
Catch and handle two cases which caused errors

### DIFF
--- a/src/components/Maps/AK_Fires.vue
+++ b/src/components/Maps/AK_Fires.vue
@@ -380,7 +380,7 @@ export default {
       return new Promise((resolve, reject) => {
         // Check if the data is in local storage
         if (!this.fireJson) {
-          this.$axios.get(process.env.FIRE_FEATURES_URL)
+          this.$axios.get(process.env.FIRE_FEATURES_URL, { timeout: 120000 })
             .then(res => {
               if (res) {
                 this.fireJson = res.data

--- a/src/components/Maps/AK_Fires_Graph.vue
+++ b/src/components/Maps/AK_Fires_Graph.vue
@@ -79,7 +79,10 @@ export default {
   name: 'AK_Fires_Graph',
   computed: {
     visible () {
-      return this.$store.state.fire.fireGraphVisible
+      // Guard in case data is unavailable to prevent error
+      return this.$store.state.fire
+        ? this.$store.state.fire.fireGraphVisible
+        : false
     },
     fireTimeSeries: {
       get () { return this.$localStorage.get('fireTimeSeries') },


### PR DESCRIPTION
 1. Timeout was too short by default for `axios`, which left the app in a broken state (not fully handled here).  Set to 2 minutes.  This is because it can take quite a while for the upstream API to refresh and regenerate.
 2. Missing fire data yielded an error on the JS console for the AK_Fires_Graph component, fixed with a guard clause.

How to test:
 * Open new terminal session, then `nc -l 2389` (Assumes `netcat` is installed)
 * Edit `config/prod.env.js` and set `FIRE_FEATURES_URL: '"http://localhost:2389"'`
 * Restart dev server (needed because the env variables changed here are only updated upon server restart)
 * Go to fire map and enjoy 2 minutes of restful peace as no data is loaded.  (You can see the request piped to the screen via `nc` though).

Then you'll be able to get the expected results, which are:
 * Console error: "Error: timeout of 120000ms exceeded" / Unhandled promise rejection,
 * NO error/warning about the state of the Store in `AK_Fires_Graph.vue`.

Issue #27 will track adding better error handling / notification in general.  This just takes care of the (entirely probable) case that the upstream service was too slow in responding.