### PR TITLE
move common map styles to MapInstanceWrapper

### DIFF
--- a/src/components/MapInstanceWrapper.vue
+++ b/src/components/MapInstanceWrapper.vue
@@ -32,4 +32,14 @@ export default {
 
 </script>
 
-<style type="scss" scoped"></style>
+<style type="scss" scoped>
+// Styles common to all maps can be put here.
+#map-instance-wrapper /deep/ h1.map-title {
+  position: absolute;
+  top: 0; left: 0;
+  z-index: 100;
+  background-color: rgba(255, 255, 255, .9);
+  margin: 0;
+  padding: .5ex;
+}
+</style>

--- a/src/components/MapInstanceWrapper.vue
+++ b/src/components/MapInstanceWrapper.vue
@@ -33,7 +33,7 @@ export default {
 </script>
 
 <style type="scss" scoped>
-// Styles common to all maps can be put here.
+/* Styles common to all maps can be put here. */
 #map-instance-wrapper /deep/ h1.map-title {
   position: absolute;
   top: 0; left: 0;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -37,16 +37,6 @@ body {
   background-screen-mode: darken;
 }
 
-/* TODO some of these styles may need to be moved elsewhere */
-h1.map-title {
-  position: absolute;
-  top: 0; left: 0;
-  z-index: 100;
-  background-color: rgba(255, 255, 255, .9);
-  margin: 0;
-  padding: .5ex;
-}
-
 // Needs to be in global scope because the Shepherd
 // library writes the DOM outside of the scope of the
 // Map component.


### PR DESCRIPTION
Keep map-specific styles out of `styles.scss` unless we really have to.  Test: the map title should appear in the normal place (upper-left), nothing else broken.