### PR TITLE
Fixes #36, repair drag and drop layer order

### DIFF
--- a/src/components/LayerList.vue
+++ b/src/components/LayerList.vue
@@ -1,18 +1,19 @@
 <template>
-<draggable v-model="layers" id="layer-list" class="layer-list">
-  <div id="top_item"></div>
-  <transition-group name="list-complete">
-    <div class="list-complete-item" v-for="layer in layers" :key="layer.name">
-      <map-layer
-        :name="layer.name"
-        :title="layer.title"
-        :abstract="layer.abstract"
-        :visible="layer.visible"
-        :secondVisible="layer.secondVisible"
-      ></map-layer>
-    </div>
-  </transition-group>
-</draggable>
+  <div id="top_item">
+    <draggable v-model="layers" id="layer-list" class="layer-list">
+      <transition-group name="list-complete">
+        <div class="list-complete-item" v-for="layer in layers" :key="layer.name">
+          <map-layer
+            :name="layer.name"
+            :title="layer.title"
+            :abstract="layer.abstract"
+            :visible="layer.visible"
+            :secondVisible="layer.secondVisible"
+          ></map-layer>
+        </div>
+      </transition-group>
+    </draggable>
+  </div>
 </template>
 
 <script>


### PR DESCRIPTION
Restores ability to drag and drop.

The problem was a weird one: the vue `draggable` requires that the immediate child be a container for the draggable elements -- but we'd put in a placeholder for the tours as the immediate child, so that broke the draggable.  Kind of subtle.

Things to check here:

 * Does the drag and drop for sort order work?
 * Do any tours that rely on those steps still run properly?