### PR TITLE
hide draft maps

### DIFF
--- a/src/components/MapList.vue
+++ b/src/components/MapList.vue
@@ -1,6 +1,6 @@
 <template>
   <ul class="map-list">
-    <li v-for="(map, key) in maps">
+    <li v-for="(map, key) in maps" v-if="!map.draft">
       <router-link :to="{ name: 'map', params: { slug: key }}">
         {{ map.title}}
       </router-link>


### PR DESCRIPTION
To test -- look at the `src/maps.js` and note which have `draft: true`.  These maps shouldn't be listed on the home page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ua-snap/mapvue/96)
<!-- Reviewable:end -->
