### PR TITLE
Implements workaround so fire layer loads normally in IE11/Win7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3073,6 +3073,11 @@
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
     },
+    "detect-browser": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-2.5.0.tgz",
+      "integrity": "sha512-PqBO0O2jBNxHTS1sTohDK03Is8cFG/HAcIwlO/v23IwiwHCK997VzzrNFz656hrZhSdVYMFaRdvKvMotKXPviA=="
+    },
     "detect-indent": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "axios": "^0.16.2",
     "babel-polyfill": "^6.26.0",
     "balloon-css": "^0.5.0",
+    "detect-browser": "^2.5.0",
     "leaflet": "1.3.1",
     "leaflet-sidebar": "0.2.0",
     "leaflet.awesome-markers": "^2.0.4",

--- a/src/components/Maps/AK_Fires.vue
+++ b/src/components/Maps/AK_Fires.vue
@@ -27,6 +27,16 @@ import MapInstance from '@/components/MapInstance'
 import AKFiresGraph from './AK_Fires_Graph'
 import Tour from '../Tour'
 import Vue from 'vue'
+const { detect } = require('detect-browser')
+const browser = detect()
+
+// Determine if we need to hack for IE11 or not.
+var isIe11
+if (browser) {
+  if (browser.name === 'ie' && browser.version === '11.0.0' && browser.os === 'Windows 7') {
+    isIe11 = true
+  }
+}
 
 // Leaflet objects, keep these outside of the
 // scope of the Vue component for performance
@@ -433,6 +443,7 @@ export default {
     showFireGraph () {
       this.$store.commit('showFireGraph')
     },
+
     fetchViirsData () {
       var processViirsData = data => {
         if (data.features.length === 0) {
@@ -510,6 +521,18 @@ export default {
                 this.fireJson = res.data
                 processFireData(res.data)
                 this.$refs.map.refreshLayers()
+                if (isIe11) {
+                  setTimeout(() => {
+                    this.$store.commit('showOnlyLayers', {
+                      first: []
+                    })
+                    setTimeout(() => {
+                      this.$store.commit('showOnlyLayers', {
+                        first: ['fires']
+                      })
+                    }, 500)
+                  }, 250)
+                }
                 resolve()
               }
             },

--- a/src/main.js
+++ b/src/main.js
@@ -9,10 +9,13 @@ import p4l from 'proj4leaflet' // eslint-disable-line
 import leaflet_sidebar from 'leaflet-sidebar' // eslint-disable-line
 import leaflet_sync from '../node_modules/leaflet.sync/L.Map.Sync.js' // eslint-disable-line
 import leaflet_awesome_markers from '../node_modules/leaflet.awesome-markers/dist/leaflet.awesome-markers.js' // eslint-disable-line
-import axios from 'axios'
 import shepherd from 'tether-shepherd'
 import moment from 'moment'
 import VueAnalytics from 'vue-analytics'
+
+// Polyfill needed for IE11 to work properly with Axios.
+require('es6-promise').polyfill()
+var axios = require('axios')
 
 Vue.use(VueAnalytics, {
   id: [process.env.MV_GOOGLE_ANALYTICS_TOKEN],


### PR DESCRIPTION
To test:
 - Ensure that the Fire map loads normally in any browser other than IE11
 - Then, log into an IE11/Win7 machine and see how it works!  Previously, only a single fire would be shown when you clicked "Show Map."  You should now see all the fires that are present.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ua-snap/mapvue/106)
<!-- Reviewable:end -->
