### PR TITLE
Adds a way to go directly to the fire graph.

### DIFF
--- a/src/components/Maps/AK_Fires.vue
+++ b/src/components/Maps/AK_Fires.vue
@@ -399,6 +399,13 @@ export default {
     this.fetchFireData()
     this.fetchViirsData()
 
+    // Is there a "graph" fragment in the query params?  If so,
+    // show the fire graph right away!
+    if (this.$route.params.overlay === 'graph') {
+      this.$store.commit('hideSplash')
+      this.showFireGraph()
+    }
+
     // Remove any stray localStorage.
     localStorage.clear()
   },

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -18,6 +18,12 @@ export default new Router({
       name: 'map',
       component: MapInstanceWrapper,
       props: true
+    },
+    {
+      path: '/map/:slug/:overlay',
+      name: 'map',
+      component: MapInstanceWrapper,
+      props: true
     }
   ]
 })


### PR DESCRIPTION
This bypasses the splash screen, too.

URL to test should be: http://localhost:8080/#/map/fires/graph

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ua-snap/mapvue/169)
<!-- Reviewable:end -->
