### PR TITLE
Hide left/right controls when a layer is local

### DIFF
--- a/src/components/MapLayer.vue
+++ b/src/components/MapLayer.vue
@@ -17,7 +17,7 @@
   <!-- Dual map controls -->
   <a
     class="split-map-controls"
-    v-if="dualMaps"
+    v-if="dualMaps && !layer.local"
   >
     <a
       class="left-right"

--- a/src/store.js
+++ b/src/store.js
@@ -93,7 +93,7 @@ export default new Vuex.Store({
       _.each(layers, layer => {
         // Default visibility on left/right maps to off
         layer.visible = layer.visible || false
-        layer.secondVisible = layer.visible
+        layer.secondVisible = false
         setWmsProperties(state, layer, layer.defaults)
         restructuredlayers.push(layer)
       })


### PR DESCRIPTION
Local layers (GeoJSON, markers, polygons) don't do the left/right split map thing.  So, don't show left/right controls for that layer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ua-snap/mapvue/170)
<!-- Reviewable:end -->
