### PR TITLE
Fetch fire data statically & reformat VIIRS to not use animation

### DIFF
--- a/config/prod.env.js
+++ b/config/prod.env.js
@@ -3,7 +3,6 @@ module.exports = {
   GEOSERVER_WMS_URL: '"http://54.70.10.93:8080/geoserver/wms/"',
   FIRE_FEATURES_URL: '"http://mv-aicc-shim-production.us-west-2.elasticbeanstalk.com/"',
   FIRE_TIME_SERIES_URL: '"http://mv-aicc-shim-production.us-west-2.elasticbeanstalk.com/fire-time-series"',
-  LIGHTNING_FEATURES_URL: '"http://mv-aicc-shim-production.us-west-2.elasticbeanstalk.com/lightning-data"',
   VIIRS_URL: '"http://mv-aicc-shim-production.us-west-2.elasticbeanstalk.com/viirs"',
   MV_GOOGLE_ANALYTICS_TOKEN: "'" + process.env.MV_GOOGLE_ANALYTICS_TOKEN + "'"
 }

--- a/config/prod.env.js
+++ b/config/prod.env.js
@@ -1,8 +1,8 @@
 module.exports = {
   NODE_ENV: '"production"',
   GEOSERVER_WMS_URL: '"http://54.70.10.93:8080/geoserver/wms/"',
-  FIRE_FEATURES_URL: '"http://mv-aicc-shim-production.us-west-2.elasticbeanstalk.com/"',
-  FIRE_TIME_SERIES_URL: '"http://mv-aicc-shim-production.us-west-2.elasticbeanstalk.com/fire-time-series"',
-  VIIRS_URL: '"http://mv-aicc-shim-production.us-west-2.elasticbeanstalk.com/viirs"',
+  FIRE_FEATURES_URL: '"http://mv-aicc-shim-production.us-west-2.elasticbeanstalk.com/fires.geojson"',
+  FIRE_TIME_SERIES_URL: '"http://mv-aicc-shim-production.us-west-2.elasticbeanstalk.com/tally.json"',
+  VIIRS_URL: '"http://mv-aicc-shim-production.us-west-2.elasticbeanstalk.com/viirs.geojson"',
   MV_GOOGLE_ANALYTICS_TOKEN: "'" + process.env.MV_GOOGLE_ANALYTICS_TOKEN + "'"
 }

--- a/src/components/Maps/AK_Fires.vue
+++ b/src/components/Maps/AK_Fires.vue
@@ -451,23 +451,20 @@ export default {
       })
     },
     getViirsMarkers (geoJson) {
-      var viirsMarkers = []
+      var geojsonMarkerOptions = {
+        radius: 5,
+        fillColor: '#FBF10A',
+        color: '#FB7202',
+        weight: 1,
+        opacity: 1,
+        fillOpacity: 0.8
+      }
 
-      _.each(geoJson.features, feature => {
-        viirsMarkers.push(
-          this.$L.circleMarker(
-            new this.$L.latLng([feature.geometry.coordinates[1], feature.geometry.coordinates[0]]),
-            {
-              radius: 5,
-              fillColor: '#F9382B',
-              fillOpacity: 1,
-              stroke: false,
-              className: 'viirs-hotspot'
-            }
-          )
-        )
+      return this.$L.geoJSON(geoJson, {
+        pointToLayer: (feature, latlng) => {
+          return this.$L.circleMarker(latlng, geojsonMarkerOptions)
+        }
       })
-      return this.$L.layerGroup(viirsMarkers)
     },
     fetchFireData () {
       // Helper function to rebuild Leaflet objects
@@ -746,17 +743,6 @@ span.fire-tour-info {
   padding: 0 .1ex;
   color: #333;
   font-weight: bold;
-}
-
-path.leaflet-interactive.viirs-hotspot {
-  animation: colors 2s infinite;
-}
-
-@keyframes colors {
-  50% {
-    fill: #F9EA31;
-    fill-opacity: 0.5;
-  }
 }
 
 .leaflet-popup-content {


### PR DESCRIPTION
See issues #155, #154.

App now processes data from remote geojson/json files instead of hitting an endpoint.  For this branch to work, you must be testing against an updated version of the mv-aicc-shim (check with me if unclear where/what that is).

VIIRS data now renders as simple GeoJSON layer, no CSS animations.  Performance is improved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ua-snap/mapvue/171)
<!-- Reviewable:end -->
