### PR TITLE
Fix layer refresh & cache issues

### DIFF
--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -134,18 +134,15 @@ export default {
     // Some of these properties are assigned in the vue store,
     // like layer.time and layer.wms.
     addWmsLayer (layer) {
-      let layerConfiguration = _.extend(this.wmsLayerOptions,
+      let layerConfiguration = {}
+      layerConfiguration = _.extend(this.wmsLayerOptions,
         {
           layers: layer.wms,
           styles: layer.styles ? layer.styles : '',
+          time: layer.time ? layer.time : '',
           id: layer.id
         }
       )
-      if (layer.time) {
-        _.extend(layerConfiguration, {
-          time: layer.time
-        })
-      }
 
       // Remove old layers if present
       if (this.$options.leaflet.layers[layer.id]) {

--- a/src/components/MapLayer.vue
+++ b/src/components/MapLayer.vue
@@ -124,6 +124,11 @@ export default {
       })
     },
     handleLayerConfigChange (data) {
+      // Update defaults so when
+      // the controls configuration changes,
+      // state is preserved when the
+      // control is rerendered (toggle layer)
+      this.layer.defaults = data
       this.$store.commit('updateLayer', {
         layer: this.id,
         properties: data


### PR DESCRIPTION
First test is to verify that cache hits are happening.

 1. Go to the Fire map
 2. Activate dev console, go to Network tab, and clear it out so there's nothing showing there.
 3. Toggle the Land Cover layer on.
 4. Examine the network request for one of the WMS requests (lots fire off at the same time, there should be a bunch).  Find the response headers.

Expected: response header `geowebcache-cache-result: HIT`

Second test is to confirm that layers with configurable properties (date, scenario, etc) show the right thing when the layer is toggled on/off.

 1. Go to the Fire Map, click Show Map.
 2. Activate the "Historical lightning strikes" layer, which defaults to May.
 3. Change the month to July.
 4. Toggle the layer off, then back on again.

Expected: the drop-down control shows July, not May.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ua-snap/mapvue/211)
<!-- Reviewable:end -->
